### PR TITLE
Better `die` behavior when rendering site creation form.

### DIFF
--- a/ssw.php
+++ b/ssw.php
@@ -724,10 +724,10 @@ if(!class_exists('Site_Setup_Wizard_NSD')) {
 
 				echo '</form>';
 				echo '</div>';
-				/* SSW Container for AJAX ends */
-				if (wp_verify_nonce($_POST['ssw_ajax_nonce'], 'ssw_ajax_action') ){
-					/* Extra wp_die is to stop ajax call from appending extra 0 to the resposne */
-					wp_die();
+
+				// Die when doing AJAX to prevent extra output.
+				if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+					die();
 				}
 			}
 		}


### PR DESCRIPTION
I was getting some PHP notices when rendering the signup wizard form, so I made some mods to the way you're killing output. See the commit message for more detail.
