### PR TITLE
Avoid PHP notices and simplify logic for 'cancel' request detection.

### DIFF
--- a/ssw.php
+++ b/ssw.php
@@ -633,7 +633,7 @@ if(!class_exists('Site_Setup_Wizard_NSD')) {
 	    		$ssw_main_table = $this->ssw_main_table();
 				
 				/* Cancel current site setup Wizard Process and restart it */
-				if( $_REQUEST['ssw_cancel'] == true )
+				if( isset( $_POST['ssw_cancel'] ) && 'true' === $_POST['ssw_cancel'] )
 				{
 					$wpdb->query( 'DELETE FROM '.$ssw_main_table.' WHERE user_id = '.$current_user_id.' and wizard_completed = false' );
                     	$this->ssw_log_sql_error($wpdb->last_error);
@@ -643,21 +643,18 @@ if(!class_exists('Site_Setup_Wizard_NSD')) {
 				}
 
 				/* Resume Site Setup Wizard from where left off before */
-				if( $_POST['ssw_cancel'] != true ) {
-					$ssw_next_stage = $wpdb->get_var( 
-						'SELECT next_stage FROM '.$ssw_main_table.' WHERE user_id = '.$current_user_id.' and wizard_completed = false'
-					);
-                    	$this->ssw_log_sql_error($wpdb->last_error);
-					
-					/* Applying Hotfix to avoid displaying Step 3 for issue with wizard freezing on Step 2 */
-					/*
-					if($ssw_next_stage != 'ssw_step2') {
-						$ssw_next_stage = '';
-					}
-					*/
+				$ssw_next_stage = $wpdb->get_var(
+					'SELECT next_stage FROM '.$ssw_main_table.' WHERE user_id = '.$current_user_id.' and wizard_completed = false'
+				);
+		$this->ssw_log_sql_error($wpdb->last_error);
+
+				/* Applying Hotfix to avoid displaying Step 3 for issue with wizard freezing on Step 2 */
+				/*
+				if($ssw_next_stage != 'ssw_step2') {
+					$ssw_next_stage = '';
 				}
 				/* Move to the next step using this POST variable "ssw_next_stage" */
-				if( $_POST['ssw_next_stage'] != '' && $_POST['ssw_cancel'] != true ) {
+				if( ! empty( $_POST['ssw_next_stage'] ) ) {
 					$ssw_next_stage = $_POST['ssw_next_stage'];
 				}
 


### PR DESCRIPTION
I eliminated some PHP notices and some duplicated logic when detecting "Cancel" requests. See commit message for more details.

The changeset also includes a fix for a notice I was getting when checking 'ssw_next_stage', which was on the same line as a 'cancel' change so I didn't put it in a separate PR :)
