### PR TITLE
Use `$wpdb` functions for insert/update.

### DIFF
--- a/admin/step1_process.php
+++ b/admin/step1_process.php
@@ -12,20 +12,31 @@
         $starttime = current_time('mysql');
 	    $endtime = $starttime;
 
-	    $previously_inserted = $wpdb->get_var( 
-	    	'SELECT COUNT(*) FROM '.$ssw_main_table.' WHERE user_id ='.$current_user_id.' and wizard_completed = false'
-	    	);
+	    $previously_inserted = $wpdb->get_var( $wpdb->prepare(
+		'SELECT COUNT(*) FROM '.$ssw_main_table.' WHERE user_id = %d and wizard_completed = false', $current_user_id
+		) );
 	        $this->ssw_log_sql_error($wpdb->last_error);
 	    	$this->ssw_debug_log('step1_process','previously_inserted',$previously_inserted);
 
 	    if( $previously_inserted == 0 ) {
-		    $result = $wpdb->query(
-		        $wpdb->prepare(
-		            "Insert into $ssw_main_table (user_id, site_usage, next_stage, starttime, endtime)
-		            Values (%d, %s, %s, %s, %s)",
-		            $current_user_id, $site_usage, $next_stage, $starttime, $endtime
-		        )
-		    );
+		$result = $wpdb->insert(
+			$ssw_main_table,
+			array(
+				'user_id'    => $current_user_id,
+				'site_usage' => $site_usage,
+				'next_stage' => $next_stage,
+				'starttime'  => $starttime,
+				'endtime'    => $endtime,
+			),
+			array(
+				'%d',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+			)
+		);
+
             	$this->ssw_log_sql_error($wpdb->last_error);
 		    
 		    if( is_wp_error( $result ) ) {

--- a/admin/step2_process.php
+++ b/admin/step2_process.php
@@ -39,12 +39,38 @@
         $next_stage = sanitize_title_for_query( $_POST['ssw_next_stage'] );
             $this->ssw_debug_log('step2_process', 'next_stage', $next_stage);
         $endtime = current_time('mysql');
-        $ssw_process_query =  'UPDATE '.$ssw_main_table.' SET user_id = \''.$current_user_id.'\', admin_email = \''.$admin_email.'\', 
-            admin_user_id = \''.$admin_user_id.'\', path = \''.$path.'\', title = \''.$title.'\', 
-            privacy = \''.$privacy.'\', next_stage = \''.$next_stage.'\', endtime = \''.$endtime.'\' WHERE user_id = '.$current_user_id.' and site_created = false and wizard_completed = false';
-            $this->ssw_debug_log('step2_process', 'ssw_process_query', $ssw_process_query);
-        
-        $result = $wpdb->query( $ssw_process_query );
+	$result = $wpdb->update(
+		$ssw_main_table,
+		array(
+			'user_id' => $current_user_id,
+			'admin_email' => $admin_email,
+			'path' => $path,
+			'title' => $title,
+			'privacy' => $private,
+			'next_stage' => $next_stage,
+			'endtime' => $endtime,
+		),
+		array(
+			'user_id' => $current_user_id,
+			'site_created' => 0,
+			'wizard_completed' => 0,
+		),
+		array(
+			'%d',
+			'%s',
+			'%s',
+			'%s',
+			'%s',
+			'%s',
+			'%s',
+		),
+		array(
+			'%d',
+			'%d',
+			'%d',
+		)
+	);
+
             $this->ssw_log_sql_error($wpdb->last_error);
         
         if ( is_wp_error( $result ) ) {


### PR DESCRIPTION
Concatenating MySQL query strings is dangerous. You are using `sanitize_title_for_query()` pretty extensively to avoid SQL injection. This is generally effective, but there are two significant problems with it:
1. You need to remember to do it. I didn't see any places where you'd forgotten, but often the sanitization takes place in a totally separate file (like with `$current_user_id`, which you're trusting from the `$current_user` global. This makes it very hard to keep track of whether you're missing something.
2. `sanitize_title_for_query()` is a very restrictive function. Anything passed through this function is sanitized using `sanitize_title_with_dashes()`, which strips everything but [a-z0-9_-]. In other words: URL-safe characters. Sometimes this is what you want. But sometimes it's way too conservative. If all you want to do is sanitize against SQL injection, `$wpdb->prepare( '...foo = %s...', $foo )` is enough.

In the attached changeset, I showed a few examples of how to use the `$wpdb` `insert()` and `update()` helpers. They do all of the SQL concatenation and sanitization for you - you just provide the values and the placeholders. (More documentation: http://codex.wordpress.org/Class_Reference/wpdb#INSERT_row)

If you don't like these helpers, and still want to concatenate `INSERT` and `UPDATE` queries - to send to your log file, for example - at the very least you should be using `$wpdb->prepare` in every case:

```
// Always
$query = $wpdb->prepare( "INSERT INTO $table (user_id,foo,bar) VALUES (%d,%s,%s)" ), $user_id, $foo, $bar );

// Never
$query = "INSERT INTO $table (user_id,foo,bar) VALUES '" . $user_id . "', '" . $foo . "', '" . $bar . "'";
```
