### PR TITLE
Remove incomplete wizard workflow when a blog is deleted

### DIFF
--- a/site-setup-wizard.php
+++ b/site-setup-wizard.php
@@ -100,6 +100,9 @@ if(!class_exists('Site_Setup_Wizard')) {
 			// Add shortcode [site_setup_wizard] to any page to display Site Setup Wizard over it
 			add_shortcode('site_setup_wizard', array( $this, 'ssw_shortcode' ) );
 			
+			// Add action to handle when a site is deleted
+			add_action( 'delete_blog', array( &$this, 'ssw_handle_site_deleted' ), 10, 1);
+			
 			// Check and store is the wordpress installation is multisite or not
 			$this->multisite = is_multisite();
 
@@ -1081,6 +1084,17 @@ if(!class_exists('Site_Setup_Wizard')) {
 					die();
 				}
 			}
+		}
+
+		/**
+		 * SSW Remove an incomplete workflow when a site is deleted
+		 *
+		 * @since  1.5.9
+		 * @return void
+		 */
+		public function ssw_handle_site_deleted($blog_id) {
+			global $wpdb;
+			$wpdb->query( 'DELETE FROM '.$this->ssw_main_table().' WHERE blog_id = '.$blog_id.' and wizard_completed = false' );
 		}
 	}
 }


### PR DESCRIPTION
Hi @neelakansha85,

Hope you're going well.

We came across an interesting scenario whereby a user started the wizard, completed the "Essential Settings" step, realised they'd made a mistake, navigated away from the wizard and then deleted the site from the site's dashboard.  They then returned to the wizard to start afresh, but were met with the last steps of the previous workflow.

This patch tries to avoid a stale state by removing the incomplete wizard row from the DB when the site is deleted.

Thanks,
Payten